### PR TITLE
Bitfinex Margin Settlement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,9 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# meta
+.DS_Store
+
+# data
+*.csv

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# cryptact-support-tools
-Cryptact Support Tools
+cryptact-support-tools
+==================
+
+# requires
+- [python3](https://www.python.org/downloads/)
+- [pandas](https://pandas.pydata.org/)
+
+# bitfinex-margin-settlement
+Bitfinexは様々な通貨を証拠金として採用できる．  
+例えば，BCHを証拠金としてBTC/USDのトレードが可能である．  
+BTC/USDで損切りした時，証拠金からUSDが引かれるが，USDがmargin walletに存在しない場合がある．  
+このとき，BitfinexはUSDに対応した額を他の通貨で決済する．  
+![参考](https://user-images.githubusercontent.com/34980690/50556960-602ba400-0d23-11e9-8210-093627102cae.png)  
+この決済はTradesの履歴には存在しないため，Cryptactで算出されたPositionと実際のPositionに差異が生じる．  
+**bitfinex-margin-settlement**は，この問題を解決するためのカスタムファイルを生成する．

--- a/bitfinex-margin-settlement/README.md
+++ b/bitfinex-margin-settlement/README.md
@@ -1,0 +1,6 @@
+How to Use
+==================
+
+1. BitfinexのReportsより，Ledersの履歴をダウンロードする，
+2. `python3 main.py csvファイル`を実行する．
+3. `custom.csv` が出力される．

--- a/bitfinex-margin-settlement/main.py
+++ b/bitfinex-margin-settlement/main.py
@@ -1,0 +1,25 @@
+import sys
+import pandas as pd
+sys.path.append('../common')
+from custom import CustomFile
+
+
+def main(filename):
+  t = pd.read_csv(filename)
+  t_settlement = t[t['DESCRIPTION'].str.contains('Settlement')]
+
+  out = CustomFile()
+
+  for i in range(0, len(t_settlement), 2):
+    buy_row  = t_settlement.iloc[i]
+    sell_row = t_settlement.iloc[i+1]
+    out.append(buy_row['DATE'], 'BUY', 'Bitfinex(custom)', buy_row['CURRENCY'], '', '', buy_row['AMOUNT'], abs(sell_row['AMOUNT'] / buy_row['AMOUNT']), sell_row['CURRENCY'], 0, 'JPY', 'Bitfinex Mergin Settlement')
+
+  out.write()
+
+
+if __name__ == '__main__':
+  if len(sys.argv) != 2:
+    print ('usage : python3 main.py filename')
+    sys.exit(1)
+  main(sys.argv[1])

--- a/common/custom.py
+++ b/common/custom.py
@@ -1,0 +1,17 @@
+import pandas as pd
+
+
+class CustomFile(object):
+  """
+  Control Custom File for Crytact
+  """
+  def __init__(self):
+    self.t = pd.DataFrame(columns=['Timestamp', 'Action', 'Source', 'Base', 'DerivType', 'DerivDetails', 'Volume', 'Price', 'Counter', 'Fee', 'FeeCcy', 'Comment'])
+
+  def append(self, *args):
+    row = pd.Series(args, index=self.t.columns)
+    self.t = self.t.append(row, ignore_index=True)
+
+
+  def write(self, filename='custom.csv'):
+    self.t.to_csv(filename, index=False)


### PR DESCRIPTION
Bitfinexは様々な通貨を証拠金として採用できる．  
例えば，BCHを証拠金としてBTC/USDのトレードが可能である．  
BTC/USDで損切りした時，証拠金からUSDが引かれるが，USDがmargin walletに存在しない場合がある．  
このとき，BitfinexはUSDに対応した額を他の通貨で決済する．  
![参考](https://user-images.githubusercontent.com/34980690/50556960-602ba400-0d23-11e9-8210-093627102cae.png)  
この決済はTradesの履歴には存在しないため，Cryptactで算出されたPositionと実際のPositionに差異が生じる．  
**bitfinex-margin-settlement**は，この問題を解決するためのカスタムファイルを生成する．